### PR TITLE
Use an env for loading assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Uses Vite's method of setting environment variables
+# https://vitejs.dev/guide/env-and-mode
+
+# The public path for asset loading, this needs to be a publically accessible URL on the
+# production version
+VITE_PUBLIC_PATH=/

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules
 
 # dotenv environment variables file
 .env
+!.env.example
 
 # Build output
 dist

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,9 +1,11 @@
 import register from 'preact-custom-element';
 
+import config from '../../config';
+
 export default function Logo() {
   return (
     <img
-      src="/recycling-locator-logo.webp"
+      src={`${config.publicPath}recycling-locator-logo.webp`}
       alt="Recycling Locator"
       width="230"
       height="42"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+const config = {
+  publicPath: import.meta.env.VITE_PUBLIC_PATH ?? '/',
+};
+
+export default config;


### PR DESCRIPTION
We'll need a publicly accessible url to load prod assets from consuming websites.

This could use the [base config option](https://vitejs.dev/config/shared-options.html#base) but it feels a bit magic I'd rather explicitly specify the public path each time so I know it's going to work.

Eventually, I think this URL will be set to unpkg